### PR TITLE
Recon Continuous AP Deauthentication

### DIFF
--- a/library/recon/access_point/continuous-ap-deauthentication/payload.sh
+++ b/library/recon/access_point/continuous-ap-deauthentication/payload.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-#Title: Continous Deauth
-#Description: Payload to continuosly deauth all devices off of a network.
+#Title: Continuous Deauth
+#Description: Payload to continuously deauth all devices off of a network.
 # Author: Jestsec
 # Version: 1
 


### PR DESCRIPTION
This is a payload to run against a access point in recon mode. This will disconnect and currently connected client and any new client trying to join as well. Please make sure you only use this on networks that you own and have permission to do so on. 

 

You need to do one thing before this is able to run. There is a bug that hasn't been patched yet(at least that im aware of) that you will need to correct to make the script functional.

1. open /usr/bin/PINEAPPLE_DEAUTH_CLIENT in nano.
2. Then change the following line:

# OLD (what you have now)
**HAK5_API_PUT "/api/pineap/deauth" "${json}" && exit 0**

to: 

# NEW (correct)
**HAK5_API_POST "pineap/deauth" "${json}" && exit 0**

After you make this change you will be able to run this payload, you will be able to use the PINEAPPLE_DEAUTH_CLIENT ducky script commands now as well. 
